### PR TITLE
Add support for octoprint 1.4.0

### DIFF
--- a/octoprint_CR10_Leveling/__init__.py
+++ b/octoprint_CR10_Leveling/__init__.py
@@ -76,6 +76,7 @@ class Cr10_levelingPlugin(octoprint.plugin.AssetPlugin,
 
 
 __plugin_name__ = "Bed Leveling Plugin"
+__plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
 
 
 def __plugin_load__():


### PR DESCRIPTION
Add __plugin_pythoncompat__  to allow the plugin to be usable under octoprint 1.4